### PR TITLE
Mapping update

### DIFF
--- a/ckanext/ddi/importer/ddiimporter.py
+++ b/ckanext/ddi/importer/ddiimporter.py
@@ -26,11 +26,17 @@ class DdiImporter(HarvesterBase):
             r = requests.get(url)
             xml_file = r.text
 
-            # fd, temp_path = tempfile.mkstemp()
-            # fd.write(xml_file.data)
             pkg_dict = ckan_metadata.load(xml_file)
-            # os.close(fd)
-            # os.remove(temp_path)
+            if pkg_dict['url'] == '':
+                pkg_dict['url'] = url
+
+            resources = []
+            resources.append({
+                'url': url,
+                'name': pkg_dict['title'],
+                'format': 'xml'
+            })
+            pkg_dict['resources'] = resources
 
         try:
             registry = ckanapi.LocalCKAN()

--- a/ckanext/ddi/templates/package/snippets/additional_info.html
+++ b/ckanext/ddi/templates/package/snippets/additional_info.html
@@ -11,7 +11,21 @@
               <p class="fieldname">{{ _(ddi_config['fields'][section][field]['display']) }}</p>
               </td>
               <td>
-              <p class="metadata">{{ pkg[field] }}</p>
+                <p class="metadata">
+                  {% if ddi_config['fields'][section][field]['type'] == 'url' %}
+                    {% set display_field = ddi_config['fields'][section][field]['display_field'] %}
+                    {% set display_text = ddi_config['fields'][section][field]['display_text'] %}
+                    {% if display_field and display_field in pkg %}
+                        <a href="{{ pkg[field] }}">{{ pkg[display_field] }}</a>
+                    {% elif display_text %}
+                        <a href="{{ pkg[field] }}">{{ display_text }}</a>
+                    {% else %}
+                        <a href="{{ pkg[field] }}">{{ pkg[field] }}</a>
+                    {% endif %}
+                  {% else %}
+                    {{ pkg[field] }}
+                  {% endif %}
+                </p>
               </td>
             <tr>
           {% endif %}


### PR DESCRIPTION
**Source**: The `url` is the "Source" field in CKAN. If we import from an URL we can actually use this value, but only if the corresponding field is not in the DDI file itself.

**Resources**: There are possibilitites to link to ressources in DDI, but as far as I saw in the examples, this is rarely used. I just add the DDI URL (i.e. the `url` from above) as a ressource, to show that it's possible to add ressources. But we should figure out how to add more ressources.

**`url` type in config.yml**: You can specify `url` as type in the config.yml, so that the content of this field is displayed as a hyperlink. To control the link text, you can either specify `display_field` to use the content of another field or specify `display_text` to use a static text. If none of those are specified, the link itself is displayed.
