### PR TITLE
Success/error message + redirect fix

### DIFF
--- a/ckanext/ddi/controllers.py
+++ b/ckanext/ddi/controllers.py
@@ -111,4 +111,5 @@ class ImportFromXml(PackageController):
             log.debug('url = ' + request.params['url'])
             id = importer.run(url=request.params['url'])
 
+        h.flash_success(_("Dataset import from XML successfully completed!"))
         redirect(h.url_for(controller='package', action='read', id=id))

--- a/ckanext/ddi/controllers.py
+++ b/ckanext/ddi/controllers.py
@@ -97,19 +97,31 @@ class ImportFromXml(PackageController):
                                   'dataset_type': package_type})
 
     def run_import(self, data=None, errors=None, error_summary=None):
-        importer = ddiimporter.DdiImporter()
+        pkg_id = None
+        try:
+            importer = ddiimporter.DdiImporter()
 
-        # Check whether upload is a file or a url
-        # If it's a url, we pass in the url to the importer.run and call it
-        # If it's a file, check whether it's a valid XML
-        # If it is a proper XML, pass it into the importer.run and call it
+            # Check whether upload is a file or a url
+            # If it's a url, we pass in the url to the importer.run and call it
+            # If it's a file, check whether it's a valid XML
+            # If it is a proper XML, pass it into the importer.run and call it
 
-        if 'upload' in request.params and request.params['upload']:
-            log.debug('upload = ' + request.params['upload'])
-            id = importer.run(file_path=request.params['upload'])
-        elif 'url' in request.params and request.params['url']:
-            log.debug('url = ' + request.params['url'])
-            id = importer.run(url=request.params['url'])
+            if 'upload' in request.params and request.params['upload']:
+                log.debug('upload = ' + request.params['upload'])
+                pkg_id = importer.run(file_path=request.params['upload'])
+            elif 'url' in request.params and request.params['url']:
+                log.debug('url = ' + request.params['url'])
+                pkg_id = importer.run(url=request.params['url'])
 
-        h.flash_success(_("Dataset import from XML successfully completed!"))
-        redirect(h.url_for(controller='package', action='read', id=id))
+            h.flash_success(
+                _("Dataset import from XML successfully completed!")
+            )
+        except Exception as e:
+            h.flash_error(
+                _("Dataset import from XML failed: %s" % str(e))
+            )
+
+        if pkg_id is not None:
+            redirect(h.url_for(controller='package', action='read', id=id))
+        else:
+            redirect(h.url_for(controller='package', action='search'))

--- a/ckanext/ddi/importer/ddiimporter.py
+++ b/ckanext/ddi/importer/ddiimporter.py
@@ -38,7 +38,7 @@ class DdiImporter(HarvesterBase):
             pkg_dict['resources'] = resources
 
         pkg_dict = self.improve_pkg_dict(pkg_dict, params)
-        self.insert_or_update_pkg(pkg_dict)
+        return self.insert_or_update_pkg(pkg_dict)
 
     def insert_or_update_pkg(self, pkg_dict):
         try:
@@ -56,6 +56,7 @@ class DdiImporter(HarvesterBase):
                 registry.call_action('package_create', pkg_dict)
 
             pprint(pkg_dict)
+            return pkg_dict['name']
         except:
             traceback.print_exc()
 


### PR DESCRIPTION
`flash_success` and `flash_error` can be used to display those flash messages on the top of the page. The try/except block makes sure that any error leads to an error message (instead of the ugly "Internal server error"). And by properly returning a reference to the newly created package, the redirect after the import now works as excepted.
