### PR TITLE
Add config options to handle duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,19 @@ To use the `nada_harvester`, make sure the [ckanext-harvest extension](https://g
 ## Configuration
 
 ### CKAN configuration (production.ini)
-Two options are available:
+Four options are available:
 
 ```bash
 ckanext.ddi.config_file = /path/to/my/config.yml
 ckanext.ddi.default_license = CC0-1.0
+ckanext.ddi.allow_duplicates = True
+ckanext.ddi.override_datasets = False
 ```
 
 The `config_file` is simply the path to the DDI-specific configuration of this extension (see below).
 The `default_license` allows a user to configure a license that is used for all DDI imports, if the license is not specified explicitly.
+The `allow_duplicates` option is used to determine, if duplicate datasets are allowed or not. Duplicates are determined by the unique `id_number` attribute (defaults to `False`).
+With `override_datasets` you can specify, if you import a dataset that already exists, if a new dataset should be created or if the existing one should be overridden (defaults to `False`).
 
 ### DDI fields configuration
 The display and structure of the DDI fields can be configured individually. A separate YAML config file is used for that.


### PR DESCRIPTION
- `allow_duplicates` determines if the system should allow duplicates to
  be imported. If they are disallowed, the users gets an error message,
  otherwise a duplicate dataset is created
- `override_datasets` determines if an existing dataset should be
  updated if it gets re-imported. Otherwise a new dataset is created
